### PR TITLE
Support for Python 3.12 `ModuleNotFound` error for missing `pkg_resources`

### DIFF
--- a/serial_interface/serial_interface.py
+++ b/serial_interface/serial_interface.py
@@ -18,7 +18,7 @@ try:
         # not installed, but there is another version that *is*
         raise SystemError
     __version__ = _dist.version
-except (DistributionNotFound, ImportError, ModuleNotFoundError, SystemError):
+except (ImportError, ModuleNotFoundError, SystemError, DistributionNotFound):
     __version__ = None
 
 

--- a/serial_interface/serial_interface.py
+++ b/serial_interface/serial_interface.py
@@ -1,49 +1,56 @@
-import serial
-import os
-import time
-from timeit import default_timer as timer
-import platform
 import atexit
 import operator
+import os
+import platform
+import serial
 import threading
-
+import time
+from timeit import default_timer as timer
 
 try:
     from pkg_resources import get_distribution, DistributionNotFound
+
     _dist = get_distribution('serial_interface')
     # Normalize case for Windows systems
     dist_loc = os.path.normcase(_dist.location)
     here = os.path.normcase(__file__)
     if not here.startswith(os.path.join(dist_loc, 'serial_interface')):
         # not installed, but there is another version that *is*
-        raise DistributionNotFound
-except (ImportError,DistributionNotFound):
-    __version__ = None
-else:
+        raise SystemError
     __version__ = _dist.version
+except (DistributionNotFound, ImportError, ModuleNotFoundError, SystemError):
+    __version__ = None
+
 
 DEBUG = False
+
 
 class WriteFrequencyError(Exception):
     def __init__(self, value=''):
         self.value = value
+
     def __str__(self):
         return repr(self.value)
+
 
 class WriteError(Exception):
     def __init__(self, value=''):
         self.value = value
+
     def __str__(self):
         return repr(self.value)
+
 
 class ReadError(Exception):
     def __init__(self, value=''):
         self.value = value
+
     def __str__(self):
         return repr(self.value)
 
+
 class SerialInterface(serial.Serial):
-    '''
+    """
     SerialInterface inherits from serial.Serial and adds methods to it,
     like auto discovery of available serial ports in Linux, Windows, and
     Mac OS X.
@@ -53,10 +60,10 @@ class SerialInterface(serial.Serial):
     dev = SerialInterface() # Might automatically find device if one available
     # if it is not found automatically, specify port directly
     dev = SerialInterface(port='/dev/ttyUSB0') # Linux
-    dev = SerialInterface(port='/dev/tty.usbmodem262471') # Mac OS X
-    dev = SerialInterface(port='COM3') # Windows
+    dev = SerialInterface(port='/dev/tty.usbmodem262471')  # Mac OS X
+    dev = SerialInterface(port='COM3')  # Windows
     dev.get_device_info()
-    '''
+    """
     _TIMEOUT = 0.05
     _WRITE_TIMEOUT = 0.05
     _WRITE_READ_DELAY = 0.001
@@ -91,40 +98,40 @@ class SerialInterface(serial.Serial):
             self.device_name = ''
 
         if ('port' not in kwargs) or (kwargs['port'] is None):
-            kwargs.update({'port': find_serial_interface_port(try_ports=try_ports,debug=self.debug)})
+            kwargs.update({'port': find_serial_interface_port(try_ports=try_ports, debug=self.debug)})
         if 'timeout' not in kwargs:
             kwargs.update({'timeout': self._TIMEOUT})
         if 'write_timeout' not in kwargs:
             kwargs.update({'write_timeout': self._WRITE_TIMEOUT})
 
-        super(SerialInterface,self).__init__(*args,**kwargs)
+        super(SerialInterface, self).__init__(*args, **kwargs)
         atexit.register(self._exit_serial_interface)
 
-        # save write_data so it can be used for debugging
+        # save `write_data` so it can be used for debugging
         self._write_data = None
-        # save bytes_written so it can be used for debugging
+        # save `bytes_written` so it can be used for debugging
         self._bytes_written = None
-        # save read_data so it can be used for debugging
+        # save `read_data` so it can be used for debugging
         self._read_data = None
 
         self._time_write_prev = timer()
         self._lock = threading.Lock()
 
     def _exit_serial_interface(self):
-        '''
+        """
         Close the serial connection to provide some clean up.
-        '''
+        """
         self.close()
 
     def _debug_print(self, *args):
-        '''
+        """
         Prints debug info if self.debug == True.
-        '''
+        """
         if self.debug:
             print(*args)
 
-    def write_check_freq(self,write_data,delay_write=False,lock_=True):
-        '''
+    def write_check_freq(self, write_data, delay_write=False, lock_=True):
+        """
         Use instead of self.write when you want to ensure that
         serial write commands do not happen too
         frequently. delay_write=True waits and then writes the serial
@@ -132,7 +139,7 @@ class SerialInterface(serial.Serial):
         Exception if time between method calls is too short. Might
         remove delay_write option if it turns out to be
         unnecessary.
-        '''
+        """
         time_now = timer()
         time_since_write_prev = time_now - self._time_write_prev
         if time_since_write_prev < self._write_write_delay:
@@ -141,16 +148,16 @@ class SerialInterface(serial.Serial):
                 time.sleep(delay_time_needed)
             else:
                 raise WriteFrequencyError("Time between writes needs to be > {0}s".format(self._write_write_delay))
-        bytes_written = 0
+
         if lock_:
-            bytes_written = self._write_check_freq_locked(write_data,delay_write)
+            bytes_written = self._write_check_freq_locked(write_data, delay_write)
         else:
             bytes_written = self._write_check_freq_unlocked(write_data)
         self._debug_print('write_data:', write_data)
         self._debug_print('bytes_written:', bytes_written)
         return bytes_written
 
-    def _write_check_freq_locked(self,write_data,blocking=True):
+    def _write_check_freq_locked(self, write_data, blocking=True):
         bytes_written = 0
         lock_acquired = self._lock.acquire(blocking)
         if not lock_acquired:
@@ -162,7 +169,7 @@ class SerialInterface(serial.Serial):
 
         return bytes_written
 
-    def _write_check_freq_unlocked(self,write_data):
+    def _write_check_freq_unlocked(self, write_data):
         self._write_data = None
         self._bytes_written = 0
         try:
@@ -171,12 +178,12 @@ class SerialInterface(serial.Serial):
                 self._bytes_written = self.write(write_data.encode())
                 self._debug_print('write_data:', self._write_data)
                 self._debug_print('bytes_written:', self._bytes_written)
-            except (UnicodeDecodeError):
+            except UnicodeDecodeError:
                 self._write_data = write_data
                 self._bytes_written = self.write(self._write_data)
             if self._bytes_written > 0:
                 self._time_write_prev = timer()
-        except (serial.SerialTimeoutException):
+        except serial.SerialTimeoutException:
             self._write_data = None
             self._bytes_written = 0
         return self._bytes_written
@@ -189,7 +196,7 @@ class SerialInterface(serial.Serial):
                    delay_write=True,
                    match_chars=False,
                    size=None):
-        '''
+        """
         A simple self.write followed by a self.readline with a
         delay set by write_read_delay when use_readline=True and
         check_write_freq=False. Setting check_write_freq=True ensures
@@ -200,9 +207,8 @@ class SerialInterface(serial.Serial):
 
         max_read_attempts opens the possibility to read from the device again
         if the device did not have the data ready after the first read
-        '''
+        """
 
-        read_data = None
         lock_acquired = self._lock.acquire(delay_write)
         if not lock_acquired:
             raise WriteFrequencyError("Time between writes needs to be larger.")
@@ -210,18 +216,18 @@ class SerialInterface(serial.Serial):
             self._write_data = None
             self._bytes_written = 0
             if check_write_freq:
-                self._bytes_written = self.write_check_freq(write_data,delay_write=delay_write,lock_=False)
+                self._bytes_written = self.write_check_freq(write_data, delay_write=delay_write, lock_=False)
             else:
                 try:
                     self._write_data = write_data.encode()
-                except (UnicodeDecodeError):
+                except UnicodeDecodeError:
                     self._write_data = write_data
                 self._bytes_written = self.write(self._write_data)
                 self._debug_print('write_data:', self._write_data)
                 self._debug_print('bytes_written:', self._bytes_written)
             if self._bytes_written > 0:
                 time.sleep(self._write_read_delay)
-                read_data = self._read_with_retry(use_readline,max_read_attempts,match_chars,size)
+                read_data = self._read_with_retry(use_readline, max_read_attempts, match_chars, size)
                 self._debug_print('read_data:', read_data)
             else:
                 self._write_data = None
@@ -230,29 +236,27 @@ class SerialInterface(serial.Serial):
             self._lock.release()
         return read_data
 
-    def _read_with_retry(self,use_readline,max_read_attempts,match_chars,size):
-        '''
+    def _read_with_retry(self, use_readline, max_read_attempts, match_chars, size):
+        """
         Reads data from the device.  If there is no data, try
         reading again.
-        '''
+        """
         i = 0
         while i < max_read_attempts:
             i += 1
-            read_data = self._read(use_readline,match_chars,size)
+            read_data = self._read(use_readline, match_chars, size)
             if read_data:
                 return read_data
 
             self._debug_print('no read_data -- retrying')
             time.sleep(self._read_read_delay)
-        if not read_data:
-            raise ReadError("No read_data received.")
-        else:
-            return read_data
 
-    def _read(self,use_readline,match_chars,size):
-        '''
+        return ReadError('No read_data received.')
+
+    def _read(self, use_readline, match_chars, size):
+        """
         Reads data from the device
-        '''
+        """
         self._read_data = None
         if size is not None:
             self._read_data = self.read(size)
@@ -273,7 +277,8 @@ class SerialInterface(serial.Serial):
         line = bytearray()
         time_now = timer()
         time_prev = time_now
-        while ((open_char_count == 0) or (close_char_count == 0) or (open_char_count != close_char_count)) and ((time_now-time_prev) <= self._TIMEOUT):
+        while ((open_char_count == 0) or (close_char_count == 0) or (open_char_count != close_char_count)) and (
+                (time_now - time_prev) <= self._TIMEOUT):
             c = self.read(1)
             time_now = timer()
             if c:
@@ -286,43 +291,47 @@ class SerialInterface(serial.Serial):
         return bytes(line)
 
     def get_device_info(self):
-        '''
+        """
         Returns device name and serial port.
-        '''
-        serial_interface_info = {'device_name' : self.device_name,
-                                 'port' : self.port,
-        }
+        """
+        serial_interface_info = {'device_name': self.device_name,
+                                 'port': self.port,
+                                 }
         return serial_interface_info
 
-    def check_write_freq(self,write_period_desired,write_data,delay_write=False):
+    def check_write_freq(self, write_period_desired, write_data, delay_write=False):
         cycle_count = 100
         time_start = timer()
         time_prev = timer()
         for cycle_n in range(cycle_count):
-            self.write_check_freq(write_data,delay_write)
+            self.write_check_freq(write_data, delay_write)
             sleep_duration = write_period_desired - (timer() - time_prev)
             if sleep_duration > 0:
                 time.sleep(sleep_duration)
             time_prev = timer()
         time_stop = timer()
-        write_period_actual = (time_stop - time_start)/cycle_count
-        print('desired write period: {0}, actual write period: {1}'.format(write_period_desired,write_period_actual))
+        write_period_actual = (time_stop - time_start) / cycle_count
+        print('desired write period: {0}, actual write period: {1}'.format(write_period_desired, write_period_actual))
 
-    def check_write_read_freq(self,write_period_desired,write_data,use_readline=True,check_write_freq=False,max_read_attempts=100,delay_write=True,match_chars=False):
+    def check_write_read_freq(self, write_period_desired, write_data, use_readline=True, check_write_freq=False,
+                              max_read_attempts=100, delay_write=True, match_chars=False):
         cycle_count = 100
         time_start = timer()
         time_prev = timer()
         read_data = ''
         for cycle_n in range(cycle_count):
-            read_data = self.write_read(write_data,use_readline,check_write_freq,max_read_attempts,delay_write,match_chars)
+            read_data = self.write_read(write_data, use_readline, check_write_freq, max_read_attempts, delay_write,
+                                        match_chars)
             sleep_duration = write_period_desired - (timer() - time_prev)
             if sleep_duration > 0:
                 time.sleep(sleep_duration)
             time_prev = timer()
         time_stop = timer()
-        write_period_actual = (time_stop - time_start)/cycle_count
-        print('desired write read period: {0}, actual write read period: {1}'.format(write_period_desired,write_period_actual))
+        write_period_actual = (time_stop - time_start) / cycle_count
+        print('desired write read period: {0}, actual write read period: {1}'.format(write_period_desired,
+                                                                                     write_period_actual))
         print('read_data: {0}'.format(read_data))
+
 
 # device_names example:
 # [{'port':'/dev/ttyACM0',
@@ -330,7 +339,7 @@ class SerialInterface(serial.Serial):
 #  {'port':'/dev/ttyACM1',
 #   'device_name':'port1'}]
 class SerialInterfaces(list):
-    '''
+    """
     SerialInterfaces inherits from list and automatically populates it
     with SerialInterfaces on all available serial ports.
 
@@ -345,9 +354,9 @@ class SerialInterfaces(list):
     devs.sort_by_port()
     dev = devs[0]
     dev.get_device_info()
-    '''
+    """
 
-    def __init__(self,*args,**kwargs):
+    def __init__(self, *args, **kwargs):
         debug = DEBUG
         if 'debug' in kwargs:
             debug = kwargs['debug']
@@ -364,67 +373,67 @@ class SerialInterfaces(list):
         if use_ports is not None:
             serial_interface_ports = use_ports
         else:
-            serial_interface_ports = find_serial_interface_ports(try_ports=try_ports,debug=debug)
+            serial_interface_ports = find_serial_interface_ports(try_ports=try_ports, debug=debug)
         for port in serial_interface_ports:
             kwargs.update({'port': port})
-            self.append_device(*args,**kwargs)
+            self.append_device(*args, **kwargs)
 
         self._update_device_names(device_names)
 
-    def _update_device_names(self,device_names):
+    def _update_device_names(self, device_names):
         for name_dict in device_names:
             device_name = name_dict.pop('device_name')
             for device_index in range(len(self)):
                 dev = self[device_index]
                 match = True
                 for key in list(name_dict.keys()):
-                    if name_dict[key] != getattr(dev,key):
+                    if name_dict[key] != getattr(dev, key):
                         match = False
                 if match:
                     dev.device_name = str(device_name)
 
-    def append_device(self,*args,**kwargs):
-        '''
+    def append_device(self, *args, **kwargs):
+        """
         Appends another SerialInterface.
-        '''
-        self.append(SerialInterface(*args,**kwargs))
+        """
+        self.append(SerialInterface(*args, **kwargs))
 
     def get_devices_info(self):
-        '''
+        """
         Get info for each SerialInterface.
-        '''
+        """
         serial_interfaces_info = []
         for dev in self:
             serial_interfaces_info.append(dev.get_device_info())
         return serial_interfaces_info
 
-    def sort_by_port(self,*args,**kwargs):
-        '''
+    def sort_by_port(self, *args, **kwargs):
+        """
         Sort SerialInterfaces by port.
-        '''
+        """
         kwargs['key'] = operator.attrgetter('port')
         self.sort(**kwargs)
 
-    def get_by_port(self,port):
-        '''
+    def get_by_port(self, port):
+        """
         Return a SerialInterface by port.
-        '''
+        """
         for device_index in range(len(self)):
             dev = self[device_index]
             if dev.port == port:
                 return dev
 
-    def sort_by_device_name(self,*args,**kwargs):
-        '''
+    def sort_by_device_name(self, *args, **kwargs):
+        """
         Sort SerialInterfaces by device names.
-        '''
-        kwargs['key'] = operator.attrgetter('device_name','port')
+        """
+        kwargs['key'] = operator.attrgetter('device_name', 'port')
         self.sort(**kwargs)
 
-    def get_by_device_name(self,device_name):
-        '''
+    def get_by_device_name(self, device_name):
+        """
         Return a SerialInterface by its device name.
-        '''
+        """
         dev_list = []
         for device_index in range(len(self)):
             dev = self[device_index]
@@ -439,18 +448,18 @@ class SerialInterfaces(list):
 # ----------------------------------------------------------------------------
 
 def find_serial_interface_ports(try_ports=None, debug=DEBUG):
-    '''
+    """
     Returns a list of all available serial ports.
     Linux: /dev/ttyUSB* or /dev/ttyACM* or /dev/*arduino*
     Mac OS X: /dev/tty.* or /dev/cu.*
     Windows: COM*
-    '''
+    """
     serial_interface_ports = []
     os_type = platform.system()
     if os_type == 'Linux':
         serial_interface_ports = os.listdir('{0}dev'.format(os.path.sep))
         serial_interface_ports = [x for x in serial_interface_ports if 'ttyUSB' in x or 'ttyACM' in x or 'arduino' in x]
-        serial_interface_ports = ['{0}dev{0}{1}'.format(os.path.sep,x) for x in serial_interface_ports]
+        serial_interface_ports = ['{0}dev{0}{1}'.format(os.path.sep, x) for x in serial_interface_ports]
     elif os_type == 'Windows':
         try:
             import winreg
@@ -476,7 +485,7 @@ def find_serial_interface_ports(try_ports=None, debug=DEBUG):
     elif os_type == 'Darwin':
         serial_interface_ports = os.listdir('{0}dev'.format(os.path.sep))
         serial_interface_ports = [x for x in serial_interface_ports if 'tty.' in x or 'cu.' in x]
-        serial_interface_ports = ['{0}dev{0}{1}'.format(os.path.sep,x) for x in serial_interface_ports]
+        serial_interface_ports = ['{0}dev{0}{1}'.format(os.path.sep, x) for x in serial_interface_ports]
 
     if try_ports is not None:
         serial_interface_ports = list(set(try_ports) & set(serial_interface_ports))
@@ -484,10 +493,11 @@ def find_serial_interface_ports(try_ports=None, debug=DEBUG):
     serial_interface_ports.sort()
     return serial_interface_ports
 
+
 def find_serial_interface_port(try_ports=None, debug=DEBUG):
-    '''
+    """
     Returns a serial port if one is available.
-    '''
+    """
     serial_interface_ports = find_serial_interface_ports(try_ports)
     if len(serial_interface_ports) == 1:
         return serial_interface_ports[0]


### PR DESCRIPTION
When I installed this on mac using pyenv 
python version `3.12.0`


It failed to import due to throwing a `ModuleNotFound` error which was not captured

also ran it through a formatter and reviewed to gave ya PEP8 compliance
I can undo that if unwanted